### PR TITLE
Use eclipse temurin for alpine images

### DIFF
--- a/11-alpine.Dockerfile
+++ b/11-alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine
+FROM eclipse-temurin:11-alpine
 
 EXPOSE 8080 8081 5005
 


### PR DESCRIPTION
We should no longer us a deprecated docker image as our base image.